### PR TITLE
Fix: add missing trailing slash in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN flutter channel beta && \
 RUN mkdir /usr/local/drinklist
 COPY . /usr/local/drinklist
 # copy custom config if available
-COPY custom_config/** /usr/local/drinklist/lib/config
+COPY custom_config/** /usr/local/drinklist/lib/config/
 WORKDIR /usr/local/drinklist
 RUN flutter build web
 


### PR DESCRIPTION
Docker requires a trailing slash in the target path when using COPY with wildcard source